### PR TITLE
Add support for valac 0.46

### DIFF
--- a/libdiodon/zeitgeist-clipboard-storage.vala
+++ b/libdiodon/zeitgeist-clipboard-storage.vala
@@ -29,8 +29,8 @@ namespace Diodon
 
         public signal void template_removed (string blacklist_id, [DBus (signature = "(asaasay)")] Variant blacklist_template);
 
-		[DBus (signature = "a{s(asaasay)}")]
-	    public abstract Variant get_templates () throws IOError;
+        [DBus (signature = "a{s(asaasay)}")]
+        public abstract Variant get_templates () throws Error;
 	}
 
 

--- a/tests/fsotest/testcase.vala
+++ b/tests/fsotest/testcase.vala
@@ -29,7 +29,7 @@ public abstract class FsoFramework.Test.TestCase : Object
 
     public delegate void TestMethod () throws GLib.Error;
 
-    public TestCase (string name)
+    protected TestCase (string name)
     {
         this._suite = new GLib.TestSuite (name);
     }


### PR DESCRIPTION
* Constructors of abstract classes may not be public
* dbus interfaces methods need to add `throw Error` in their signature