### PR TITLE
Release 1.9.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,7 @@
 #   Oliver Sauder <os@esite.ch>
 
 project('diodon', ['vala', 'c'],
-    version: '1.9.0-daily',
+    version: '1.9.0',
     license: 'GPLv2+',
     default_options: [
         'warning_level=1',


### PR DESCRIPTION
I have been running [Diodon Daily PPA](https://launchpad.net/~diodon-team/+archive/ubuntu/daily) on my Ubuntu 18.04 machine and Diodon seems to work just as fine being built with Meson.

Unless you have different results I think we are ready for another release.