### PR TITLE
Switch from app indicator to ayatana app indicator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 before_install:
     - sudo apt-add-repository --yes ppa:vala-team
     - sudo apt-get update --quiet
-    - sudo apt-get install --yes valac libglib2.0-dev intltool libappindicator3-dev libgtk-3-dev libpeas-dev libunity-dev libxtst-dev libzeitgeist-2.0-dev meson desktop-file-utils xvfb at-spi2-core
+    - sudo apt-get install --yes valac libglib2.0-dev intltool libayatana-appindicator3-dev libgtk-3-dev libpeas-dev libunity-dev libxtst-dev libzeitgeist-2.0-dev meson desktop-file-utils xvfb at-spi2-core
 
 script:
     - meson builddir

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ pkgpluginsdatadir = join_paths(pkgdatadir, 'plugins')
 
 # Dependencies
 if not get_option('disable-indicator-plugin')
-	appindicator_dep = dependency('appindicator3-0.1', version: '>=0.3.0')
+	appindicator_dep = dependency('ayatana-appindicator3-0.1', version: '>=0.5.3')
 endif
 if get_option('enable-unity-scope')
 	unity_dep = dependency('unity', version: '>=7.1.0')


### PR DESCRIPTION
AppIndicator has been deprecated in Debian and has been superseded by Ayatana App Indicator.

See https://ayatanaindicators.github.io/

I have tested this and it seems to work just as before even on Ubuntu 18.04. Once this is committed I will update the packaging as well so we can test it in our Daily PPA.