### PR TITLE
Enable using of diodon specific icons with Yaru theme

### DIFF
--- a/data/icons/Yaru/scalable/apps/diodon.svg
+++ b/data/icons/Yaru/scalable/apps/diodon.svg
@@ -1,0 +1,1 @@
+../../../hicolor/scalable/apps/diodon.svg

--- a/data/icons/Yaru/scalable/status/diodon-panel.svg
+++ b/data/icons/Yaru/scalable/status/diodon-panel.svg
@@ -1,0 +1,1 @@
+../../../ubuntu-mono-dark/status/24/diodon-panel.svg

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -51,3 +51,8 @@ install_data(join_paths('ubuntu-mono-light', 'status', '22', 'diodon-panel.svg')
     install_dir: join_paths(datadir, 'icons', 'ubuntu-mono-light', 'status', '22'))
 install_data(join_paths('ubuntu-mono-light', 'status', '24', 'diodon-panel.svg'),
     install_dir: join_paths(datadir, 'icons', 'ubuntu-mono-light', 'status', '24'))
+
+install_data(join_paths('Yaru', 'scalable', 'status', 'diodon-panel.svg'),
+    install_dir: join_paths(datadir, 'icons', 'Yaru', 'scalable', 'status'))
+install_data(join_paths('Yaru', 'scalable', 'apps', 'diodon.svg'),
+    install_dir: join_paths(datadir, 'icons', 'Yaru', 'scalable', 'apps'))


### PR DESCRIPTION
This shows proper icons when using Ubuntu 20.04.