### PR TITLE
Remove IRC channel reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,3 @@ If you would like to write your own Diodon plugin please refer to [the original 
 ## Support
 
 Take part in the discussion or report a bug on the [launchpad](https://bugs.launchpad.net/diodon) page.
-
-Join us in #diodon on irc.freenode.net if you want to get involved or need any help.


### PR DESCRIPTION
As I am not using IRC anymore in case @RedHatter you are also not connected to this channel frequently it is better to remove this support reference from the README.