### PR TITLE
Remove discontinued gedit valencia plugin support

### DIFF
--- a/.valencia
+++ b/.valencia
@@ -1,4 +1,0 @@
-version = 1
-build_command = ./waf build
-clean_command = ./waf clean
-pkg_blacklist = gdk-2.0.vapi;gdk-x11-2.0.vapi;gtk+-2.0.vapi

--- a/configure.in
+++ b/configure.in
@@ -1,2 +1,0 @@
-# this is a dummy file so valencia knows where the root is
-# see http://redmine.yorba.org/issues/3410


### PR DESCRIPTION
Valencia Gedit Plugin is [discontinued](https://wiki.gnome.org/Projects/Vala/Tools) since 2014.