### PR TITLE
Remove setting of rpath for diodon binary

### DIFF
--- a/diodon/meson.build
+++ b/diodon/meson.build
@@ -26,5 +26,4 @@ diodon = executable('diodon',
     ],
     link_with: [libdiodon],
     include_directories: [libdiodon_inc],
-    install: true,
-    install_rpath: bindir)
+    install: true)


### PR DESCRIPTION
This is an attempt to fix custom-library-search-path

See https://lintian.debian.org/tags/custom-library-search-path