### PR TITLE
updated github action to work with latest LTS versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
     name: Run test - Ubuntu ${{ matrix.ubuntu-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,15 @@
 name: Tests
 on: [push, pull_request]
-
 jobs:
   test:
-    name: Run test
-    runs-on: ubuntu-20.04
+    name: Run test - Ubuntu ${{ matrix.ubuntu-version }}
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}
+    strategy:
+      matrix:
+        ubuntu-version: ['22.04', '24.04']
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get update --quiet


### PR DESCRIPTION
20.04 LTS is deprecated, the actual supported LTS versions are 22.04 and 24.04, changed the pipeline to work on it.