### PR TITLE
Ensured that substring is correctly called

### DIFF
--- a/libdiodon/file-clipboard-item.vala
+++ b/libdiodon/file-clipboard-item.vala
@@ -75,7 +75,8 @@ namespace Diodon
                 _label += p.replace(home, "~");
 
                 if (_label.char_count() > 50) {
-                    _label = _label.substring(0, 50) + "...";
+                    long index_char = _label.index_of_nth_char(50);
+                    _label = _label.substring(0, index_char) + "...";
                     break;
                 }
             }

--- a/libdiodon/text-clipboard-item.vala
+++ b/libdiodon/text-clipboard-item.vala
@@ -51,7 +51,8 @@ namespace Diodon
             // label should not be longer than 50 letters
             _label = _text;
             if (_label.char_count() > 50) {
-                _label = _label.substring(0, 50) + "...";
+                long index_char = _label.index_of_nth_char(50);
+                _label = _label.substring(0, index_char) + "...";
             }
             _label = _label.replace("\n", " ");
         }


### PR DESCRIPTION
This is an oversight in #50 as [substring](https://valadoc.org/glib-2.0/string.substring.html) len is actually number of bytes.