### PR TITLE
Do not recalculate checksum when loading from zeitgeist storage

### DIFF
--- a/libdiodon/file-clipboard-item.vala
+++ b/libdiodon/file-clipboard-item.vala
@@ -48,13 +48,16 @@ namespace Diodon
          * @param data paths separated with \n
          * @param origin origin of clipboard item as application path
          */
-        public FileClipboardItem(ClipboardType clipboard_type, string data, string? origin, DateTime date_copied) throws FileError
+        public FileClipboardItem(ClipboardType clipboard_type, string data, string? origin, DateTime date_copied, string? checksum = null) throws FileError
         {
             _clipboard_type = clipboard_type;
             _paths = data;
             _origin = origin;
             _date_copied = date_copied;
-            _checksum = Checksum.compute_for_string(ChecksumType.SHA1, _paths);
+            _checksum = checksum;
+            if(_checksum == null) {
+                _checksum = Checksum.compute_for_string(ChecksumType.SHA1, _paths);
+            }
 
             // check if all paths are available
             string[] paths = convert_to_paths(_paths);

--- a/libdiodon/image-clipboard-item.vala
+++ b/libdiodon/image-clipboard-item.vala
@@ -45,27 +45,37 @@ namespace Diodon
             _clipboard_type = clipboard_type;
             _origin = origin;
             _date_copied = date_copied;
-            extract_pixbuf_info(pixbuf);
+
+            // create checksum of picture
+            Checksum checksum = new Checksum(ChecksumType.SHA1);
+            checksum.update(pixbuf.get_pixels(), pixbuf.height * pixbuf.rowstride);
+            _checksum = checksum.get_string().dup();
+
+            // label in format [{width}x{height}]
+            _label ="[%dx%d]".printf(pixbuf.width, pixbuf.height);
+            _pixbuf = pixbuf;
         }
 
         /**
          * Create image clipboard item by given payload.
          *
          * @param clipboard_type clipboard type item is coming from
+         * @param clipboard_type label how it will be shown to user
          * @param pixbuf image from clipboard
          * @param origin origin of clipboard item as application path
          */
-        public ImageClipboardItem.with_payload(ClipboardType clipboard_type, ByteArray payload, string? origin, DateTime date_copied) throws GLib.Error
+        public ImageClipboardItem.with_payload(ClipboardType clipboard_type, string label, ByteArray payload, string? origin, DateTime date_copied, string checksum) throws GLib.Error
         {
             _clipboard_type = clipboard_type;
             _origin = origin;
             _date_copied = date_copied;
+            _label = label;
+            _checksum = checksum;
 
             Gdk.PixbufLoader loader = new Gdk.PixbufLoader();
             loader.write(payload.data);
             loader.close();
-            Gdk.Pixbuf pixbuf = loader.get_pixbuf();
-            extract_pixbuf_info(pixbuf);
+            _pixbuf = loader.get_pixbuf();
         }
 
         /**
@@ -199,24 +209,6 @@ namespace Diodon
         {
             // use checksum to create hash code
             return str_hash(_checksum);
-        }
-
-        /**
-         * Extracts all pixbuf information which are needed to show image
-         * in the view without having the pixbuf in the memory.
-         *
-         * @param pixbuf pixbuf to extract info from
-         */
-        private void extract_pixbuf_info(Gdk.Pixbuf pixbuf)
-        {
-            // create checksum of picture
-            Checksum checksum = new Checksum(ChecksumType.SHA1);
-            checksum.update(pixbuf.get_pixels(), pixbuf.height * pixbuf.rowstride);
-            _checksum = checksum.get_string().dup();
-
-            // label in format [{width}x{height}]
-            _label ="[%dx%d]".printf(pixbuf.width, pixbuf.height);
-            _pixbuf = pixbuf;
         }
 
         /**

--- a/libdiodon/text-clipboard-item.vala
+++ b/libdiodon/text-clipboard-item.vala
@@ -40,13 +40,16 @@ namespace Diodon
          * @param data simple text
          * @param origin origin of clipboard item as application path
          */
-        public TextClipboardItem(ClipboardType clipboard_type, string data, string? origin, DateTime date_copied)
+        public TextClipboardItem(ClipboardType clipboard_type, string data, string? origin, DateTime date_copied, string? checksum = null)
         {
             _clipboard_type = clipboard_type;
             _text = data;
             _origin = origin;
             _date_copied = date_copied;
-            _checksum = Checksum.compute_for_string(ChecksumType.SHA1, _text);
+            _checksum = checksum;
+            if(_checksum == null) {
+                _checksum = Checksum.compute_for_string(ChecksumType.SHA1, _text);
+            }
 
             // label should not be longer than 50 letters
             _label = _text;

--- a/libdiodon/zeitgeist-clipboard-storage.vala
+++ b/libdiodon/zeitgeist-clipboard-storage.vala
@@ -532,21 +532,22 @@ namespace Diodon
             string interpretation = subject.interpretation;
             IClipboardItem item = null;
             string text = subject.text;
+            string checksum = subject.uri.split(":")[1];
             string? origin = subject.origin;
             unowned ByteArray payload = event.payload;
             DateTime date_copied = new DateTime.from_unix_utc(event.timestamp);
 
             try {
                 if(strcmp(NFO.PLAIN_TEXT_DOCUMENT, interpretation) == 0) {
-                   item = new TextClipboardItem(ClipboardType.NONE, text, origin, date_copied);
+                   item = new TextClipboardItem(ClipboardType.NONE, text, origin, date_copied, checksum);
                 }
 
                 else if(strcmp(NFO.FILE_DATA_OBJECT, interpretation) == 0) {
-                    item = new FileClipboardItem(ClipboardType.NONE, text, origin, date_copied);
+                    item = new FileClipboardItem(ClipboardType.NONE, text, origin, date_copied, checksum);
                 }
 
                 else if(strcmp(NFO.IMAGE, interpretation) == 0) {
-                    item = new ImageClipboardItem.with_payload(ClipboardType.NONE, payload, origin, date_copied);
+                    item = new ImageClipboardItem.with_payload(ClipboardType.NONE, text, payload, origin, date_copied, checksum);
                 }
 
                 else {

--- a/tests/test-image-clipboard-item.vala
+++ b/tests/test-image-clipboard-item.vala
@@ -39,10 +39,13 @@ namespace Diodon
             ImageClipboardItem item1 = new ImageClipboardItem.with_image(ClipboardType.CLIPBOARD, pixbuf, null, new DateTime.now_utc());
             string checksum1 = item1.get_checksum();
 
-            ImageClipboardItem item2 = new ImageClipboardItem.with_payload(ClipboardType.CLIPBOARD, item1.get_payload(), null, new DateTime.now_utc());
+            ImageClipboardItem item2 = new ImageClipboardItem.with_payload(
+                ClipboardType.CLIPBOARD, "[64x64]", item1.get_payload(), null, new DateTime.now_utc(), item1.get_checksum()
+            );
             string checksum2 = item2.get_checksum();
 
             FsoFramework.Test.Assert.are_equal_string(checksum1, checksum2, "Images are not the same");
+            FsoFramework.Test.Assert.are_equal_string(item1.get_label(), item2.get_label(), "Labels are not the same");
 	    }
 	}
 }


### PR DESCRIPTION
Zeitgeist already contains the checksum in the URI so no need to recalculate it.